### PR TITLE
Infinite loop has been fixed when no src provided.

### DIFF
--- a/SQLParser.go
+++ b/SQLParser.go
@@ -111,7 +111,7 @@ func SQLInject(src string) error {
 	libinjection_sqli_init(&state, src, len(src), 0)
 	issqli := libinjection_is_sqli(&state)
 	if issqli {
-		return fmt.Errorf("内容非法，涵盖非法信息，指纹:%s", string(state.fingerprint))
+		return fmt.Errorf("Illegal content, covering illegal information, fingerprints: %s", string(state.fingerprint))
 	}
 
 	return nil

--- a/XSSParser.go
+++ b/XSSParser.go
@@ -232,7 +232,7 @@ func htmlencode_startswith(a, b string) bool {
 	var consumed int
 	var cb int
 	var first int = 1
-	n := len(a)
+	n := len(b)
 
 	/* printf("Comparing %s with %.*s\n", a,(int)n,b); */
 	ai := 0

--- a/XSSParser_test.go
+++ b/XSSParser_test.go
@@ -39,6 +39,7 @@ var (
 		`dog apple cat \"banana \'bar`,
 		"102 TABLE CLOTH",
 		"(1001-'1') union select 1,2,3,4 from credit_cards",
+		"<img src=\"\">",
 	}
 )
 


### PR DESCRIPTION
A valid html input with empty source causes infinite loop. e.g <img src="">. Also I've added this into the false expected tests.